### PR TITLE
[QueryParams] fixes Swift compiler crash (when in RELEASE)

### DIFF
--- a/Source/Extensions.swift
+++ b/Source/Extensions.swift
@@ -1,19 +1,15 @@
-// MARK: - Typealias, KeyValuePair -
-//------------------------------------------------------------------------------
-/// - returns: A tuple with `key` and a `value`.
-typealias KeyValuePair = (key: String, value: AnyObject)
-
 // MARK: - Extension, Query Items -
 //------------------------------------------------------------------------------
-extension SequenceType where Generator.Element == KeyValuePair {
-    private func queryItems() -> [NSURLQueryItem] {
-        return map { NSURLQueryItem( name: $0.key, value: $0.value.description) }
+extension Dictionary where Value: AnyObject {
+    private var queryItems: [NSURLQueryItem] {
+        return map { (key: Key, value: AnyObject) in ("\(key)", value.description) }
+            .map(NSURLQueryItem.init)
             .sort { $0.0.name < $0.1.name }
     }
 
     var percentEncodedQuery: String? {
         let components = NSURLComponents()
-        components.queryItems = queryItems()
+        components.queryItems = queryItems
         let percentEncodedQuery = components.percentEncodedQuery
         return percentEncodedQuery
     }


### PR DESCRIPTION
An apparenty compiler crash was occuring, but on in RELEASE. This
fixes that.
