### PR TITLE
Carthage update, update expectation test for 'int' collection

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,5 +1,5 @@
 github "Quick/Nimble" "v5.1.1"
-github "Quick/Quick" "v1.0.0"
-github "antitypical/Result" "3.1.0"
+github "Quick/Quick" "v1.1.0"
+github "antitypical/Result" "3.2.0"
 github "jspahrsummers/xcconfigs" "3d9d99634cae6d586e272543d527681283b33eb0"
-github "ReactiveCocoa/ReactiveSwift" "1.0.0"
+github "ReactiveCocoa/ReactiveSwift" "1.1.0"

--- a/Tests/JSONRequestTests.swift
+++ b/Tests/JSONRequestTests.swift
@@ -40,7 +40,7 @@ class JSONRequestTests: QuickSpec {
                     .startWithResult { (result: Result<[Int], NetworkError>) in
                         colors = result.value 
                 }
-                expect(colors?.count).toEventually(equal(513), timeout: 5)
+                expect(colors?.count).toEventually(equal(519), timeout: 5)
             }
         }
     }


### PR DESCRIPTION
# What's new
- updates to ReactiveSwift 1.1.0 (ReactiveCocoa 5.0.1 requires ReactiveSwift 1.1.0)
- updates expectation for 'int' collection test